### PR TITLE
removing graphein and instead using rdkit to parse the pdb files

### DIFF
--- a/molecules_binding/datasets.py
+++ b/molecules_binding/datasets.py
@@ -35,7 +35,7 @@ def create_edges_protein_ligand(num_atoms_ligand, num_atoms_protein,
 class GraphDataset(Dataset):
     """ builds the graph for each complex"""
 
-    def __init__(self, pdb_files, aff_d, threshold, which_file_ligand):
+    def __init__(self, pdb_files, aff_d, threshold):
         """
         Args:
             pdb_files: list with triplets containing
@@ -53,13 +53,11 @@ class GraphDataset(Dataset):
         for comp_name, path_protein, path_ligand in pdb_files:
 
             (ligand_coord, atoms_ligand, edges_ligand, edges_length_ligand,
-             num_atoms_ligand) = molecule_info(path_ligand, "Ligand", 0,
-                                               which_file_ligand)
+             num_atoms_ligand) = molecule_info(path_ligand, "Ligand", 0)
 
             (protein_coord, atoms_protein, edges_protein, edges_length_protein,
              num_atoms_protein) = molecule_info(path_protein, "Protein",
-                                                num_atoms_ligand,
-                                                which_file_ligand)
+                                                num_atoms_ligand)
 
             edges_both, edges_dis_both = create_edges_protein_ligand(
                 num_atoms_ligand, num_atoms_protein, ligand_coord,
@@ -103,7 +101,7 @@ class VectorDataset(torch.utils.data.Dataset):
     """ constructs a vector with coordinates padded and flatten
     (both the ligand and protein) and one-hot chemical element"""
 
-    def __init__(self, pdb_files, aff_dict, which_file_ligand):
+    def __init__(self, pdb_files, aff_dict):
         """
         Args:
             pdb_files: list with triplets containing
@@ -123,13 +121,11 @@ class VectorDataset(torch.utils.data.Dataset):
         for comp_name, path_protein, path_ligand in pdb_files:
 
             (ligand_coord, atoms_ligand, _, _,
-             num_atoms_ligand) = molecule_info(path_ligand, "Ligand", 0,
-                                               which_file_ligand)
+             num_atoms_ligand) = molecule_info(path_ligand, "Ligand", 0)
 
             (protein_coord, atoms_protein, _, _,
              num_atoms_protein) = molecule_info(path_protein, "Protein",
-                                                num_atoms_ligand,
-                                                which_file_ligand)
+                                                num_atoms_ligand)
 
             max_len_l = max(max_len_l, num_atoms_ligand)
             max_len_p = max(max_len_p, num_atoms_protein)

--- a/molecules_binding/parsers.py
+++ b/molecules_binding/parsers.py
@@ -83,9 +83,10 @@ def vector2onehot(vector, n_features):
     return onehotvector
 
 
-def molecule_info(path, type_mol, num_atoms_additional, which_file_ligand):
+def molecule_info(path, type_mol, num_atoms_additional):
     """from path returns the coordinates, atoms and
     bonds of molecule"""
+
     if type_mol == "Protein":
         molecule = Chem.MolFromPDBFile(path,
                                        flavor=2,
@@ -93,10 +94,10 @@ def molecule_info(path, type_mol, num_atoms_additional, which_file_ligand):
                                        removeHs=False)
 
     elif type_mol == "Ligand":
-        if which_file_ligand == "sdf":
+        if path[-4:] == ".sdf":
             molecule = Chem.SDMolSupplier(path, sanitize=False,
                                           removeHs=False)[0]
-        elif which_file_ligand == "mol2":
+        elif path[-4:] == "mol2":
             molecule = Chem.MolFromMol2File(path,
                                             sanitize=False,
                                             removeHs=False)

--- a/scripts/process_dataset.py
+++ b/scripts/process_dataset.py
@@ -42,11 +42,10 @@ def create_dataset(direct: str, affinity_directory: str, path: str,
     affinity_dict = get_affinities(affinity_directory)
 
     if which_model == "graphnet":
-        datasetg = GraphDataset(pdb_files, affinity_dict, threshold,
-                                which_file_ligand)
+        datasetg = GraphDataset(pdb_files, affinity_dict, threshold)
         torch.save(datasetg, path)
     elif which_model == "mlp":
-        datasetv = VectorDataset(pdb_files, affinity_dict, which_file_ligand)
+        datasetv = VectorDataset(pdb_files, affinity_dict)
         torch.save(datasetv, path)
 
 


### PR DESCRIPTION
Chem (from rdkit) is now the package used to get the bonds and the atoms from both the pdb and sdf files. (it also reads mol2 files). 
I had to change the default of the Chem functions to sanitize=False, because if true, some molecules would have errors I couldn't solve otherwise. I don't know the implications of doing that, but "Sanitization is the process of checking and correcting the molecule to ensure that it has a valid chemical structure. It can include for example removing duplicate atoms and bonds, checking for and correcting valence errors, and correcting chiral errors". 

As said in the emails, more atoms appeared, so I changed the one-hot representations as "jones2021improved" does, grouping the atoms that are halogens and the metals.