### PR TITLE
new file graphnet tune to integrate ray tune

### DIFF
--- a/scripts/graphnet_tune.py
+++ b/scripts/graphnet_tune.py
@@ -30,8 +30,6 @@ flags.DEFINE_list("weight_decays", [0, 0.0001],
                   "the weight decays to experiment with")
 flags.DEFINE_float("train_perc", 0.9, "percentage of train-validation-split")
 flags.DEFINE_integer("splitting_seed", 42, "Seed for splitting dataset")
-# flags.DEFINE_list("num_hidden_graph", [64, 96, 128],
-#                   "size of message passing layers")
 flags.DEFINE_multi_string("dim_message_passing_layers", None,
                           "try different numbers of message passing layers")
 flags.DEFINE_multi_string("dim_fully_connected_layers", None,
@@ -118,7 +116,7 @@ def train(config, train_dataset, val_dataset, batch_size, max_epochs, comment,
         callbacks = [
             loss_callback, metrics_callback, early_stopping_callback, report
         ]
-        print("callbacks created")
+
     accelerator = "gpu" if use_gpu else None
 
     trainer = Trainer(max_epochs=max_epochs,


### PR DESCRIPTION
Created a file `graphnet_tune.py` to run Ray Tune.
Right now there are 5 parameters that can be tuned:

- learning rate
- dropout rate
- message passing layers (size and number)
- fully connected layers (size and number)
- weight devay

for example, we can run
`python scripts/graphnet_tune.py --path_dataset=datasetpath  --dropout_rates=0,0.1 --learning_rates=0.001,0.0001 --dim_message_passing_layers="128 128 128" --dim_message_passing_layers="128 128" --dim_fully_connected_layers="200 200" --dim_fully_connected_layers="200" --weight_decays=0,0.0001`
and this will create 32 experiments (each parameter was given 2 possibilities) with each combination.

There are still some things missing:

 - which dataset (including different versions of the dataset, for example with different distance thresholds or different initial features);
 - using the ASHAScheduler to discard bad runs and focus on the best hyperparameter combinations, and therefore optimize the search;