### PR TITLE
dataset is now an hyperparameter which can be tuned

### DIFF
--- a/scripts/graphnet_tune.py
+++ b/scripts/graphnet_tune.py
@@ -17,10 +17,6 @@ from ray import tune
 
 FLAGS = flags.FLAGS
 
-# flags.DEFINE_string("path_dataset", None,
-#                     "specify the path to the stored processed dataset")
-# flags.mark_flag_as_required("path_dataset")
-
 flags.DEFINE_list("paths_dataset", None, "specify the path to the datasets")
 
 flags.DEFINE_list("learning_rates", [0.1, 0.01, 0.001, 0.0001, 0.00001],


### PR DESCRIPTION
Modified `graphnet_tune.py`. Now we can use different datasets from different paths to test with ray tune.
Now we can tune 6 parameters in total:

- learning rate
- dropout rate
- message passing layers (size and number)
- fully connected layers (size and number)
- weight decay
- dataset (for example, datasets with different features or different distance thresholds)