### PR TITLE
passing the model to float 32 and including the pdb id of each graph

### DIFF
--- a/molecules_binding/datasets_interaction.py
+++ b/molecules_binding/datasets_interaction.py
@@ -110,8 +110,8 @@ def create_edges_protein_ligand(num_atoms_ligand, num_atoms_protein,
 
         edges_features[i] += edge_ind_attr
 
-    edges_both = torch.as_tensor([rows_both, cols_both])
-    edges_features = torch.as_tensor(edges_features)
+    edges_both = torch.as_tensor([rows_both, cols_both], dtype=torch.int64)
+    edges_features = torch.as_tensor(edges_features, dtype=torch.float32)
 
     return edges_both, edges_features
 
@@ -188,7 +188,11 @@ class GraphDataset(data.Dataset):
                                   edge_index=edges,
                                   pos=coords,
                                   edge_attr=edges_atrr,
-                                  y=torch.as_tensor(np.float64(affinity)))
+                                  y=[
+                                      torch.as_tensor(affinity,
+                                                      dtype=torch.float32),
+                                      str(pdb_id)
+                                  ])
                     ]
 
         print(correctly_parsed)

--- a/molecules_binding/lightning_wrapper.py
+++ b/molecules_binding/lightning_wrapper.py
@@ -28,7 +28,7 @@ class GraphNNLightning(pl.LightningModule):
         self.use_message_passing = use_message_passing
 
     def compute_statistics(self, data, training):
-        labels = data.y
+        labels = data.y[0]
         outputs = self.model(data, data.batch, self.dropout_rate,
                              self.use_message_passing).squeeze()
 
@@ -36,6 +36,7 @@ class GraphNNLightning(pl.LightningModule):
             loss = self.criterion(labels, outputs)
             return loss, None, None, None, None
 
+        labels = labels.squeeze()
         loss = self.criterion(labels, outputs)
         mae = F.l1_loss(outputs, labels)
         rmse = torch.sqrt(loss)

--- a/molecules_binding/parsers.py
+++ b/molecules_binding/parsers.py
@@ -219,3 +219,25 @@ CASF_2016_core_set = {
     '2wtv', '2j7h', '2yki', '4agn', '5c28', '3ge7', '4ivd', '3f3c', '3e93',
     '1pxn', '2qbp', '4ea2', '2weg', '3n76', '3fcq'
 }
+
+files_with_error = {
+    '3p3h', '3p3j', '3p44', '3p55', '4i60', '4jfv', '4jfw', '4jhq', '4um9',
+    '2vnp', '3vjs', '2z3z', '2zjw', '3bwf', '2rib', '2jdk', '3pup', '3dcq',
+    '2c5y', '1ppw', '4avt', '3wax', '3zp9', '3egk', '2fov', '2q2n', '4c4n',
+    '1qon', '4ie3', '3cst', '5a3o', '4ixv', '3wc5', '4hmq', '1rdn', '4z7n',
+    '4rlp', '2eep', '4gql', '4m3b', '2foy', '2jdu', '1h07', '2a5b', '2wfg',
+    '2jdp', '2vr0', '2ci9', '4hxq', '3vjt', '4daw', '3lp1', '2a3w', '1epq',
+    '3v9b', '4hww', '3eyd', '2cfd', '2w08', '4hze', '3whw', '1r1h', '3e9b',
+    '4fxz', '4ayu', '3lil', '1ai6', '4z7s', '1sl3', '1esz', '3kck', '4z7f',
+    '2z97', '2fou', '2nwn', '2jsd', '2aoh', '2cfg', '2boj', '2boi', '1biw',
+    '3gpe', '3e6k', '4mma', '2jdy', '1a7x', '2g83', '4avs', '4kw6', '1z3j',
+    '4kcx', '2ork', '1mue', '2brh', '2bv4', '4ob1', '3q4c', '1ksn', '2pll',
+    '3kqr', '4fil', '4x1r', '3lik', '3qlb', '1hyz', '2jdn', '2ggx', '4ob0',
+    '4m3f', '3udn', '4ixu', '4ob2', '2wl4', '2jdm', '1bm6', '3w8o', '4kai',
+    '2ria', '2jdh', '2yak', '4kb7', '1q54', '4mm4', '2os9', '2fm5', '2ggu',
+    '4abd', '3lp2', '4u0x', '4no1', '4aoc', '1cps', '4mm6', '4dcx', '3lir',
+    '3zdv', '1k2v', '4kbi', '3rj7', '4wkv', '4lv1', '1rdl', '3h9f', '1nu1',
+    '4z7q', '4wku', '1rdi', '3m1s', '2jbl', '1bcj', '4wkt', '3zju', '3l2y',
+    '4wk2', '2fuu', '4iu0', '4l6q', '3zjt', '1f92', '3fxz', '3bho', '3fy0',
+    '1qpf', '1rdj', '4ie2', '4i06', '1g7v'
+}

--- a/molecules_binding/parsers_interaction.py
+++ b/molecules_binding/parsers_interaction.py
@@ -116,9 +116,10 @@ def molecule_info(path, type_mol, num_atoms_ligand):
             *[atom.GetIsAromatic()], *onehot_number_of_hs, *onehot_chirality
         ]]
 
-    atom_features = torch.as_tensor(atom_features)
+    atom_features = torch.as_tensor(atom_features, dtype=torch.float32)
 
     coords = conformer.GetPositions()
+    coords = torch.as_tensor(coords, dtype=torch.float32)
 
     rows_l = []
     cols_l = []
@@ -150,7 +151,7 @@ def molecule_info(path, type_mol, num_atoms_ligand):
             *onehot_bond_stereo, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
         ]]
 
-    edges = torch.as_tensor([rows_l, cols_l])
+    edges = torch.as_tensor([rows_l, cols_l], dtype=torch.int64)
 
-    edges_features = torch.as_tensor(edges_features)
+    edges_features = torch.as_tensor(edges_features, dtype=torch.float32)
     return (coords, atom_features, edges, edges_features, num_atoms)

--- a/scripts/process_dataset_interaction.py
+++ b/scripts/process_dataset_interaction.py
@@ -26,7 +26,7 @@ flags.mark_flag_as_required("path_dataset")
 flags.DEFINE_float("threshold", 6,
                    "maximum length of edges between protein and ligand")
 
-flags.DEFINE_enum("which_file_ligand", "sdf", ["sdf", "mol2"],
+flags.DEFINE_enum("which_file_ligand", "mol2", ["sdf", "mol2"],
                   "can choose either mol2 or sdf files")
 
 flags.DEFINE_enum("which_model", "graphnet", ["graphnet", "mlp"],
@@ -49,6 +49,11 @@ def create_dataset(direct: str, affinity_dir: str, path: str, threshold: float,
 
     pdb_files = parsers.read_dataset(direct, which_file_ligand,
                                      which_file_protein, affinity_dict)
+
+    pdb_files = [
+        pdb_file for pdb_file in pdb_files
+        if pdb_file[0] not in parsers.files_with_error
+    ]
 
     if not_include_test_set:
         pdb_files = [

--- a/scripts/train_graphnet_lightning.py
+++ b/scripts/train_graphnet_lightning.py
@@ -151,8 +151,6 @@ def main(_):
                                    FLAGS.size_processing_steps,
                                    FLAGS.num_processing_steps)
 
-    model.double()
-
     lightning_model = lightning_wrapper.GraphNNLightning(
         model, FLAGS.learning_rate, FLAGS.batch_size, FLAGS.dropout_rate,
         FLAGS.weight_decay, FLAGS.use_message_passing)


### PR DESCRIPTION
Now

- All the parameters, both in the dataset features and the model are of `dtype=torch.float32` (except the edge indexes, which are `torch.dtype=int64` because it is required by torch geometric.
- One important thing that was missing was having each graph associated with its pdb identification (if some problem happens, for example, the problem of the edges not having correct labels we can have access the complex id that has that problem)

Note that with these changes, the parsed datasets used need to be updated too,  so I already parsed them and stored them, so that those are the ones to be used from now on. 